### PR TITLE
Dynamic assemblies cannot be loaded

### DIFF
--- a/Platforms/MugenMvvmToolkit.WPF(4.5)/Infrastructure/WpfBootstrapperBase.cs
+++ b/Platforms/MugenMvvmToolkit.WPF(4.5)/Infrastructure/WpfBootstrapperBase.cs
@@ -152,7 +152,7 @@ namespace MugenMvvmToolkit.WPF.Infrastructure
         protected virtual ICollection<Assembly> GetAssemblies()
         {
             var assemblies = new HashSet<Assembly>();
-            foreach (Assembly assembly in AppDomain.CurrentDomain.GetAssemblies())
+            foreach (Assembly assembly in AppDomain.CurrentDomain.GetAssemblies().Where(x=>!x.IsDynamic))
             {
                 if (assemblies.Add(assembly))
                     assemblies.AddRange(assembly.GetReferencedAssemblies().Select(Assembly.Load));

--- a/Platforms/MugenMvvmToolkit.WinForms(4.5)/Infrastructure/WinFormsBootstrapperBase.cs
+++ b/Platforms/MugenMvvmToolkit.WinForms(4.5)/Infrastructure/WinFormsBootstrapperBase.cs
@@ -113,7 +113,7 @@ namespace MugenMvvmToolkit.WinForms.Infrastructure
         protected virtual ICollection<Assembly> GetAssemblies()
         {
             var assemblies = new HashSet<Assembly>();
-            foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
+            foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies().Where(x=>!x.IsDynamic))
             {
                 if (assemblies.Add(assembly))
                     assemblies.AddRange(assembly.GetReferencedAssemblies().Select(Assembly.Load));

--- a/Platforms/MugenMvvmToolkit.Xamarin.Forms/Infrastructure/XamarinFormsBootstrapperBase.cs
+++ b/Platforms/MugenMvvmToolkit.Xamarin.Forms/Infrastructure/XamarinFormsBootstrapperBase.cs
@@ -174,7 +174,7 @@ namespace MugenMvvmToolkit.Xamarin.Forms.Infrastructure
         {
             if (_platformService == null)
                 return new[] { GetType().GetTypeInfo().Assembly, typeof(BootstrapperBase).GetTypeInfo().Assembly };
-            return _platformService.GetAssemblies();
+            return _platformService.GetAssemblies().Where(x=>!x.IsDynamic).ToList();
         }
 
         [CanBeNull]


### PR DESCRIPTION
In my project I have types which are proxied with Castle.
Castle creates dynamic assembly. 
And if my type is instantiated before the bootstrap starts,
the bootstrapper starts traversing for dynamic assemblies as well and look for local storage location of the dynamic assemlies and the appication crashes.
