### PR TITLE
Deleted

### DIFF
--- a/Core/MugenMvvmToolkit.Core(4.0)/MugenMvvmToolkit.Core(4.0).csproj
+++ b/Core/MugenMvvmToolkit.Core(4.0)/MugenMvvmToolkit.Core(4.0).csproj
@@ -200,6 +200,21 @@
     <Compile Include="..\mugenmvvmtoolkit.core%28NetStandard%29\infrastructure\ReferenceEqualityComparer.cs">
       <Link>Infrastructure\ReferenceEqualityComparer.cs</Link>
     </Compile>
+    <Compile Include="..\MugenMvvmToolkit.Core%28NetStandard%29\Infrastructure\Requests\RequestHandlerBase.cs">
+      <Link>Infrastructure\Requests\RequestHandlerBase.cs</Link>
+    </Compile>
+    <Compile Include="..\MugenMvvmToolkit.Core%28NetStandard%29\Infrastructure\Requests\RequestHandlerProvider.cs">
+      <Link>Infrastructure\Requests\RequestHandlerProvider.cs</Link>
+    </Compile>
+    <Compile Include="..\MugenMvvmToolkit.Core%28NetStandard%29\Infrastructure\Requests\ResponseBase.cs">
+      <Link>Infrastructure\Requests\ResponseBase.cs</Link>
+    </Compile>
+    <Compile Include="..\MugenMvvmToolkit.Core%28NetStandard%29\Infrastructure\Requests\ResponseError.cs">
+      <Link>Infrastructure\Requests\ResponseError.cs</Link>
+    </Compile>
+    <Compile Include="..\MugenMvvmToolkit.Core%28NetStandard%29\Infrastructure\Requests\ResponseStatus.cs">
+      <Link>Infrastructure\Requests\ResponseStatus.cs</Link>
+    </Compile>
     <Compile Include="..\mugenmvvmtoolkit.core%28NetStandard%29\infrastructure\Serializer.cs">
       <Link>Infrastructure\Serializer.cs</Link>
     </Compile>
@@ -421,6 +436,12 @@
     </Compile>
     <Compile Include="..\mugenmvvmtoolkit.core%28NetStandard%29\interfaces\presenters\IViewModelPresenter.cs">
       <Link>Interfaces\Presenters\IViewModelPresenter.cs</Link>
+    </Compile>
+    <Compile Include="..\MugenMvvmToolkit.Core%28NetStandard%29\Interfaces\Requests\IRequest.cs">
+      <Link>Interfaces\Requests\IRequest.cs</Link>
+    </Compile>
+    <Compile Include="..\MugenMvvmToolkit.Core%28NetStandard%29\Interfaces\Requests\IRequestHandlerProvider.cs">
+      <Link>Interfaces\Requests\IRequestHandlerProvider.cs</Link>
     </Compile>
     <Compile Include="..\mugenmvvmtoolkit.core%28NetStandard%29\interfaces\validation\INotifyDataErrorInfo.cs">
       <Link>Interfaces\Validation\INotifyDataErrorInfo.cs</Link>

--- a/Core/MugenMvvmToolkit.Core(NetStandard)/ApplicationSettings.cs
+++ b/Core/MugenMvvmToolkit.Core(NetStandard)/ApplicationSettings.cs
@@ -88,9 +88,11 @@ namespace MugenMvvmToolkit
 
         public static bool GridViewModelEnableSelectableInterface { get; set; }
 
-        public static bool ViewMappingProviderDisableAutoRegistration { get; set; }
+	    public static bool ViewMappingProviderDisableAutoRegistration { get; set; }
 
-        public static bool SerializerDisableAutoRegistration { get; set; }
+	    public static bool RequestHandlerProviderDisableAutoRegistration { get; set; }
+		
+		public static bool SerializerDisableAutoRegistration { get; set; }
 
         public static bool ViewManagerAlwaysCreateNewView { get; set; }
 

--- a/Core/MugenMvvmToolkit.Core(NetStandard)/ApplicationSettings.cs
+++ b/Core/MugenMvvmToolkit.Core(NetStandard)/ApplicationSettings.cs
@@ -40,7 +40,7 @@ namespace MugenMvvmToolkit
         public const int CodeBuilderLowPriority = -100;
 
         public const string DataContractNamespace = "http://schemas.mugenmvvmtoolkit.com";
-        public const string AssemblyVersion = "6.5.0.0";
+        public const string AssemblyVersion = "6.6.0.0";
         public const string AssemblyCopyright = "Copyright (c) 2012-2017 Vyacheslav Volkov";
         public const string AssemblyCompany = "Vyacheslav Volkov";
 

--- a/Core/MugenMvvmToolkit.Core(NetStandard)/ExceptionManager.cs
+++ b/Core/MugenMvvmToolkit.Core(NetStandard)/ExceptionManager.cs
@@ -84,7 +84,17 @@ namespace MugenMvvmToolkit
             return new InvalidOperationException($@"Unable to find a suitable view model for the '{viewType}'.");
         }
 
-        internal static Exception ViewModelCannotBeRestored()
+	    internal static Exception RequestHandlerNotFound(Type requestType)
+	    {
+		    return new InvalidOperationException($@"Unable to find a suitable request handler for the '{requestType}'.");
+		}
+
+	    internal static Exception RequestHandlerNotRegistered(Type requestHandlerType)
+	    {
+		    return new InvalidOperationException($@"Request handler '{requestHandlerType}' not registered in IOC container.");
+		}
+
+		internal static Exception ViewModelCannotBeRestored()
         {
             return new InvalidOperationException("Unable to restore a view model.");
         }

--- a/Core/MugenMvvmToolkit.Core(NetStandard)/Infrastructure/Requests/RequestHandlerBase.cs
+++ b/Core/MugenMvvmToolkit.Core(NetStandard)/Infrastructure/Requests/RequestHandlerBase.cs
@@ -1,0 +1,130 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using MugenMvvmToolkit.Interfaces.Requests;
+
+namespace MugenMvvmToolkit.Infrastructure.Requests
+{
+	public abstract class RequestHandlerBase<TRequest, TResponse>
+		where TRequest : IRequest<TResponse>
+		where TResponse : ResponseBase, new()
+	{
+
+		IRequestHandlerProvider _requestHandlerProvider;
+
+		IRequestHandlerProvider RequestHandler
+		{
+			get
+			{
+				if (_requestHandlerProvider != null)
+					return _requestHandlerProvider;
+				_requestHandlerProvider = ToolkitServiceProvider.RequestHandlerProvider;
+				return _requestHandlerProvider;
+			}
+		}
+
+		protected Task<TInternalResponse> SendAsync<TInternalResponse>(IRequest<TInternalResponse> request) where TInternalResponse : ResponseBase, new()
+		{
+			return RequestHandler.SendAsync(request);
+		}
+
+		protected abstract Task<TResponse> HandleAsync(TRequest request);
+
+		protected Task<TResponse> Ok(TResponse response)
+		{
+#if NET_STANDARD
+			return Task.FromResult(response);
+#else
+			return new Task<TResponse>(() => response);
+#endif
+		}
+
+		protected Task<TResponse> Fail(string errorCode)
+		{
+#if NET_STANDARD
+			return Task.FromResult(new TResponse()
+			{
+				ResponseStatus = new ResponseStatus(errorCode)
+			});
+#else
+			return new Task<TResponse>(() => new TResponse()
+			{
+				ResponseStatus = new ResponseStatus(errorCode)
+			});
+#endif
+		}
+
+		protected Task<TResponse> Fail(string errorCode, string message)
+		{
+#if NET_STANDARD
+			return Task.FromResult(new TResponse()
+			{
+				ResponseStatus = new ResponseStatus(errorCode, message)
+			});
+#else
+			return new Task<TResponse>(() => new TResponse()
+			{
+				ResponseStatus = new ResponseStatus(errorCode, message)
+			});
+#endif
+		}
+
+		protected Task<TResponse> FailWithUnauthorized()
+		{
+#if NET_STANDARD
+			return Task.FromResult(new TResponse()
+			{
+				ResponseStatus = new ResponseStatus(nameof(ResponseBase.Unauthorized), ResponseBase.Unauthorized)
+			});
+#else
+			return new Task<TResponse>(() => new TResponse()
+			{
+				ResponseStatus = new ResponseStatus(nameof(ResponseBase.Unauthorized), ResponseBase.Unauthorized)
+			});
+#endif
+		}
+
+		protected Task<TResponse> FailWithException(Exception e)
+		{
+
+			var response = new ResponseStatus(nameof(ResponseBase.UnhandledException), ResponseBase.UnhandledException)
+			{
+				Errors = new List<ResponseError>()
+				{
+					new ResponseError()
+					{
+						ErrorCode = e.GetType().ToString(),
+						Message = e.Message,
+						StackTrace = e.StackTrace
+					}
+				}
+			};
+#if NET_STANDARD
+			return Task.FromResult(new TResponse()
+			{
+				ResponseStatus = response
+			});
+#else
+			return new Task<TResponse>(() => new TResponse()
+			{
+				ResponseStatus = response
+			});
+#endif
+		}
+
+		protected Task<TResponse> FailWithNoNetwork()
+		{
+#if NET_STANDARD
+			return Task.FromResult(new TResponse()
+			{
+				ResponseStatus = new ResponseStatus(nameof(ResponseBase.NoNetwork), ResponseBase.NoNetwork)
+			});
+#else
+			return new Task<TResponse>(() => new TResponse()
+			{
+				ResponseStatus = new ResponseStatus(nameof(ResponseBase.NoNetwork), ResponseBase.NoNetwork)
+			});
+#endif
+		}
+	}
+}

--- a/Core/MugenMvvmToolkit.Core(NetStandard)/Infrastructure/Requests/RequestHandlerProvider.cs
+++ b/Core/MugenMvvmToolkit.Core(NetStandard)/Infrastructure/Requests/RequestHandlerProvider.cs
@@ -1,0 +1,180 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+using JetBrains.Annotations;
+using MugenMvvmToolkit.Attributes;
+using MugenMvvmToolkit.Interfaces;
+using MugenMvvmToolkit.Interfaces.Requests;
+using MugenMvvmToolkit.Models;
+using MugenMvvmToolkit.Models.IoC;
+
+namespace MugenMvvmToolkit.Infrastructure.Requests
+{
+	public class RequestHandlerProvider : IRequestHandlerProvider
+	{
+		private readonly IIocContainer _iocContainer;
+		private IEnumerable<Assembly> _assemblies;
+		private Dictionary<Type, Type> _registeredHandlers;
+
+		[Preserve(Conditional = true)]
+		public RequestHandlerProvider([NotNull] IIocContainer iocContainer, [NotNull] IEnumerable<Assembly> assemblies)
+		{
+			Should.NotBeNull(iocContainer, nameof(iocContainer));
+			Should.NotBeNull(assemblies, nameof(assemblies));
+			_iocContainer = iocContainer;
+			_assemblies = assemblies;
+			_registeredHandlers = new Dictionary<Type, Type>();
+		}
+
+		public Task<TResponse> SendAsync<TResponse>(IRequest<TResponse> request) where TResponse : ResponseBase, new()
+		{
+			EnsureInitialized();
+
+			if (!_registeredHandlers.TryGetValue(request.GetType(), out var handlerType))
+				throw ExceptionManager.RequestHandlerNotFound(request.GetType());
+			if (!_iocContainer.TryGet(handlerType, out var handler))
+				throw ExceptionManager.RequestHandlerNotRegistered(handlerType);
+
+			var method = handlerType.GetMethodEx("HandleAsync", MemberFlags.NonPublic | MemberFlags.Instance);
+			var result = (Task<TResponse>)method.Invoke(handler, new object[] { request });
+			return result;
+		}
+
+		private void EnsureInitialized()
+		{
+			if (_assemblies == null)
+				return;
+			if (ApplicationSettings.RequestHandlerProviderDisableAutoRegistration)
+			{
+				_assemblies = null;
+				return;
+			}
+
+			lock (_registeredHandlers)
+			{
+				var assemblies = _assemblies;
+				_assemblies = null;
+				if (ToolkitServiceProvider.IsDesignMode)
+					assemblies = assemblies.FilterDesignAssemblies();
+
+				if (!ApplicationSettings.RequestHandlerProviderDisableAutoRegistration)
+				{
+					//TODO
+					ToolkitServiceProvider.BootstrapCodeBuilder?.AppendStatic(nameof(ApplicationSettings),
+						$"{typeof(ApplicationSettings).FullName}.{nameof(ApplicationSettings.RequestHandlerProviderDisableAutoRegistration)} = true;");
+				}
+
+				InitializeMapping(assemblies.SelectMany(assembly =>
+					assembly.SafeGetTypes(!ToolkitServiceProvider.IsDesignMode)));
+			}
+		}
+
+		protected virtual void InitializeMapping(IEnumerable<Type> types)
+		{
+			foreach (var type in types)
+			{
+#if NET_STANDARD
+				var typeInfo = type.GetTypeInfo();
+				if (typeInfo.IsAbstract || typeInfo.IsInterface)
+					continue;
+
+#else
+                if (type.IsAbstract || type.IsInterface)
+                    continue;
+
+#endif
+
+				if (InheritsOrImplements(type, typeof(RequestHandlerBase<,>)))
+				{
+					var requestType = BaseType(type).GetGenericArguments()[0];
+					AddMapping(requestType, type);
+				}
+
+			}
+		}
+
+		public void AddMapping(Type request, Type requestHandler)
+		{
+			if (!_registeredHandlers.ContainsKey(request))
+			{
+				_registeredHandlers.Add(request, requestHandler);
+			}
+			else
+			{
+				_registeredHandlers[request] = requestHandler;
+				_iocContainer.Unbind(requestHandler);
+			}
+			_iocContainer.Bind(requestHandler, requestHandler, DependencyLifecycle.SingleInstance);
+
+			if (Tracer.TraceInformation)
+				Tracer.Info("The request handler mapping to request was created: ({0} ---> {1})",
+					request, requestHandler);
+		}
+
+		static bool InheritsOrImplements(Type child, Type parent)
+		{
+			parent = ResolveGenericTypeDefinition(parent);
+
+			var currentChild = IsGenericType(child)
+				? child.GetGenericTypeDefinition()
+				: child;
+
+			while (currentChild != typeof(object))
+			{
+				if (parent == currentChild || HasAnyInterfaces(parent, currentChild))
+					return true;
+
+				currentChild = BaseType(currentChild) != null
+				               && IsGenericType(BaseType(currentChild))
+					? BaseType(currentChild).GetGenericTypeDefinition()
+					: BaseType(currentChild);
+
+				if (currentChild == null)
+					return false;
+			}
+			return false;
+		}
+
+		private static bool HasAnyInterfaces(Type parent, Type child)
+		{
+			return child.GetInterfaces()
+				.Any(childInterface =>
+				{
+					var currentInterface = IsGenericType(childInterface)
+						? childInterface.GetGenericTypeDefinition()
+						: childInterface;
+
+					return currentInterface == parent;
+				});
+		}
+
+		private static Type ResolveGenericTypeDefinition(Type parent)
+		{
+			var shouldUseGenericType = !(IsGenericType(parent) && parent.GetGenericTypeDefinition() != parent);
+
+			if (IsGenericType(parent) && shouldUseGenericType)
+				parent = parent.GetGenericTypeDefinition();
+			return parent;
+		}
+
+		private static bool IsGenericType(Type type)
+		{
+#if NET_STANDARD
+			return type.GetTypeInfo().IsGenericType;
+#else
+			return type.IsGenericType;
+#endif
+		}
+
+		private static Type BaseType(Type type)
+		{
+#if NET_STANDARD
+			return type.GetTypeInfo().BaseType;
+#else
+			return type.BaseType;
+#endif
+		}
+	}
+}

--- a/Core/MugenMvvmToolkit.Core(NetStandard)/Infrastructure/Requests/ResponseBase.cs
+++ b/Core/MugenMvvmToolkit.Core(NetStandard)/Infrastructure/Requests/ResponseBase.cs
@@ -1,0 +1,30 @@
+﻿namespace MugenMvvmToolkit.Infrastructure.Requests
+{
+	public class ResponseBase
+	{
+		public ResponseStatus ResponseStatus { get; set; }
+
+		public bool IsSuccess()
+		{
+			return ResponseStatus == null;
+		}
+
+		public bool IsFailure() => !IsSuccess();
+
+		public bool IsNoNetworkFailure()
+		{
+			if (IsSuccess()) return false;
+			return ResponseStatus.ErrorCode == nameof(NoNetwork);
+		}
+
+		public bool IsUnauthorized()
+		{
+			if (IsSuccess()) return false;
+			return ResponseStatus.ErrorCode == nameof(Unauthorized);
+		}
+
+		internal const string NoNetwork = "No network connection available";
+		internal const string UnhandledException = "Unexpected error occured";
+		internal const string Unauthorized = "Not authorized to perform this action";
+	}
+}

--- a/Core/MugenMvvmToolkit.Core(NetStandard)/Infrastructure/Requests/ResponseError.cs
+++ b/Core/MugenMvvmToolkit.Core(NetStandard)/Infrastructure/Requests/ResponseError.cs
@@ -1,0 +1,13 @@
+﻿using System.Collections.Generic;
+
+namespace MugenMvvmToolkit.Infrastructure.Requests
+{
+	public sealed class ResponseError
+	{
+		public string ErrorCode { get; set; }
+		public string FieldName { get; set; }
+		public string Message { get; set; }
+		public string StackTrace { get; set; }
+		public Dictionary<string, string> Meta { get; set; }
+	}
+}

--- a/Core/MugenMvvmToolkit.Core(NetStandard)/Infrastructure/Requests/ResponseStatus.cs
+++ b/Core/MugenMvvmToolkit.Core(NetStandard)/Infrastructure/Requests/ResponseStatus.cs
@@ -1,0 +1,27 @@
+﻿using System.Collections.Generic;
+
+namespace MugenMvvmToolkit.Infrastructure.Requests
+{
+	public sealed class ResponseStatus
+	{
+		public ResponseStatus()
+		{
+		}
+
+		public ResponseStatus(string errorCode)
+		{
+			ErrorCode = errorCode;
+		}
+
+		public ResponseStatus(string errorCode, string message)
+		{
+			ErrorCode = errorCode;
+			Message = message;
+		}
+
+		public string ErrorCode { get; set; }
+		public string Message { get; set; }
+		public List<ResponseError> Errors { get; set; }
+		public Dictionary<string, string> Meta { get; set; }
+	}
+}

--- a/Core/MugenMvvmToolkit.Core(NetStandard)/Interfaces/Requests/IRequest.cs
+++ b/Core/MugenMvvmToolkit.Core(NetStandard)/Interfaces/Requests/IRequest.cs
@@ -1,0 +1,9 @@
+﻿using MugenMvvmToolkit.Infrastructure.Requests;
+
+namespace MugenMvvmToolkit.Interfaces.Requests
+{
+	public interface IRequest<TResponse> where TResponse : ResponseBase
+	{
+
+	}
+}

--- a/Core/MugenMvvmToolkit.Core(NetStandard)/Interfaces/Requests/IRequestHandlerProvider.cs
+++ b/Core/MugenMvvmToolkit.Core(NetStandard)/Interfaces/Requests/IRequestHandlerProvider.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Threading.Tasks;
+using MugenMvvmToolkit.Infrastructure.Requests;
+
+namespace MugenMvvmToolkit.Interfaces.Requests
+{
+	public interface IRequestHandlerProvider
+	{
+		Task<TResponse> SendAsync<TResponse>(IRequest<TResponse> request) where TResponse : ResponseBase, new();
+		void AddMapping(Type request, Type requestHandler);
+	}
+}

--- a/Core/MugenMvvmToolkit.Core(NetStandard)/Interfaces/ViewModels/IViewModel.cs
+++ b/Core/MugenMvvmToolkit.Core(NetStandard)/Interfaces/ViewModels/IViewModel.cs
@@ -19,8 +19,11 @@
 using System;
 using System.Collections.Generic;
 using System.Threading;
+using System.Threading.Tasks;
 using JetBrains.Annotations;
+using MugenMvvmToolkit.Infrastructure.Requests;
 using MugenMvvmToolkit.Interfaces.Models;
+using MugenMvvmToolkit.Interfaces.Requests;
 using MugenMvvmToolkit.Models;
 
 namespace MugenMvvmToolkit.Interfaces.ViewModels
@@ -52,6 +55,10 @@ namespace MugenMvvmToolkit.Interfaces.ViewModels
         [NotNull]
         IList<IBusyToken> GetBusyTokens();
 
-        event EventHandler<IViewModel, EventArgs> Initialized;
+	    IRequestHandlerProvider RequestHandler { get; }
+
+	    Task<TResponse> SendAsync<TResponse>(IRequest<TResponse> request) where TResponse : ResponseBase, new();
+
+		event EventHandler<IViewModel, EventArgs> Initialized;
     }
 }

--- a/Core/MugenMvvmToolkit.Core(NetStandard)/Modules/InitializationModuleBase.cs
+++ b/Core/MugenMvvmToolkit.Core(NetStandard)/Modules/InitializationModuleBase.cs
@@ -20,12 +20,14 @@ using MugenMvvmToolkit.Infrastructure;
 using MugenMvvmToolkit.Infrastructure.Callbacks;
 using MugenMvvmToolkit.Infrastructure.Navigation;
 using MugenMvvmToolkit.Infrastructure.Presenters;
+using MugenMvvmToolkit.Infrastructure.Requests;
 using MugenMvvmToolkit.Infrastructure.Validation;
 using MugenMvvmToolkit.Interfaces;
 using MugenMvvmToolkit.Interfaces.Callbacks;
 using MugenMvvmToolkit.Interfaces.Models;
 using MugenMvvmToolkit.Interfaces.Navigation;
 using MugenMvvmToolkit.Interfaces.Presenters;
+using MugenMvvmToolkit.Interfaces.Requests;
 using MugenMvvmToolkit.Interfaces.Validation;
 using MugenMvvmToolkit.Models;
 using MugenMvvmToolkit.Models.IoC;
@@ -73,7 +75,15 @@ namespace MugenMvvmToolkit.Modules
             container.BindToConstant(mappingProvider);
         }
 
-        protected virtual void BindViewManager(IModuleContext context, IIocContainer container)
+	    protected virtual void BindRequestHandlerProvider(IModuleContext context, IIocContainer container)
+	    {
+		    IRequestHandlerProvider requestHandlerProvider = new RequestHandlerProvider(container, context.Assemblies);
+		    ToolkitServiceProvider.RequestHandlerProvider = requestHandlerProvider;
+		    container.BindToConstant(requestHandlerProvider);
+		}
+
+
+		protected virtual void BindViewManager(IModuleContext context, IIocContainer container)
         {
             container.Bind<IViewManager, ViewManager>(DependencyLifecycle.SingleInstance);
         }
@@ -177,7 +187,8 @@ namespace MugenMvvmToolkit.Modules
             BindOperationCallbackFactory(context, context.IocContainer);
             BindOperationCallbackStateManager(context, context.IocContainer);
             BindViewMappingProvider(context, context.IocContainer);
-            BindViewManager(context, context.IocContainer);
+	        BindRequestHandlerProvider(context, context.IocContainer);
+			BindViewManager(context, context.IocContainer);
             BindDisplayNameProvider(context, context.IocContainer);
             BindViewModelProvider(context, context.IocContainer);
             BindMessagePresenter(context, context.IocContainer);

--- a/Core/MugenMvvmToolkit.Core(NetStandard)/MugenMvvmToolkit.Core(NetStandard).csproj
+++ b/Core/MugenMvvmToolkit.Core(NetStandard)/MugenMvvmToolkit.Core(NetStandard).csproj
@@ -46,7 +46,14 @@
     <Compile Include="Infrastructure\BootstrapCodeBuilder.cs" />
     <Compile Include="Infrastructure\Callbacks\CallbackDictionary.cs" />
     <Compile Include="Infrastructure\CompositeEqualityComparer.cs" />
+    <Compile Include="Infrastructure\Requests\RequestHandlerBase.cs" />
+    <Compile Include="Infrastructure\Requests\RequestHandlerProvider.cs" />
+    <Compile Include="Infrastructure\Requests\ResponseBase.cs" />
+    <Compile Include="Infrastructure\Requests\ResponseError.cs" />
+    <Compile Include="Infrastructure\Requests\ResponseStatus.cs" />
     <Compile Include="Interfaces\Navigation\IOpenedViewModelInfo.cs" />
+    <Compile Include="Interfaces\Requests\IRequest.cs" />
+    <Compile Include="Interfaces\Requests\IRequestHandlerProvider.cs" />
     <Compile Include="Interfaces\Views\ICleanableView.cs" />
     <Compile Include="Interfaces\Views\IHasFallbackMappingView.cs" />
     <Compile Include="Interfaces\Views\IInitializableView.cs" />

--- a/Core/MugenMvvmToolkit.Core(NetStandard)/ToolkitServiceProvider.cs
+++ b/Core/MugenMvvmToolkit.Core(NetStandard)/ToolkitServiceProvider.cs
@@ -27,6 +27,7 @@ using MugenMvvmToolkit.Infrastructure;
 using MugenMvvmToolkit.Interfaces;
 using MugenMvvmToolkit.Interfaces.Callbacks;
 using MugenMvvmToolkit.Interfaces.Models;
+using MugenMvvmToolkit.Interfaces.Requests;
 using MugenMvvmToolkit.Interfaces.ViewModels;
 using MugenMvvmToolkit.Models;
 
@@ -45,8 +46,9 @@ namespace MugenMvvmToolkit
         private static IReflectionManager _reflectionManager;
         private static IValidatorProvider _validatorProvider;
         private static IEventAggregator _eventAggregator;
+	    private static IRequestHandlerProvider _requestHandlerProvider;
 
-        private static Func<object, IEventAggregator> _instanceEventAggregatorFactory;
+		private static Func<object, IEventAggregator> _instanceEventAggregatorFactory;
         private static Func<object, WeakReference> _weakReferenceFactory;
         private static IViewModelProvider _viewModelProvider;
         private static Func<IViewModel, IViewModelSettings> _viewModelSettingsFactory;
@@ -203,7 +205,14 @@ namespace MugenMvvmToolkit
             set { _eventAggregator = value; }
         }
 
-        public static event EventHandler Initialized;
+	    [NotNull]
+	    public static IRequestHandlerProvider RequestHandlerProvider
+	    {
+		    get { return _requestHandlerProvider; }
+		    set { _requestHandlerProvider = value; }
+		}
+
+		public static event EventHandler Initialized;
 
         #endregion
 
@@ -224,7 +233,8 @@ namespace MugenMvvmToolkit
             TryInitialize(iocContainer, ref _validatorProvider);
             TryInitialize(iocContainer, ref _viewModelProvider);
             TryInitialize(iocContainer, ref _eventAggregator);
-            TryInitialize(iocContainer, ref _viewManager);
+	        TryInitialize(iocContainer, ref _requestHandlerProvider);
+			TryInitialize(iocContainer, ref _viewManager);
 
             if (OperationCallbackStateManager == null)
             {


### PR DESCRIPTION
Hi
As discussed some time ago, my changes to add a business component handler to the toolkit.
Idea is to have a definition for a request (request and response object) and that a handler for the request can be registered (automatically via ioc). Then in the viewmodel you can execute such a request via the `SendAsync` method and the input object.
I think this is a great addition to the toolkit.

If accepted, can you create 6.6 nuget packages?
Thanks.